### PR TITLE
Fix capitalization on install mode

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -35,10 +35,10 @@ Make targets and options:
 - lib: compile the static library
 - BITS=32 or BITS=64: compile for specified 32-bit or 64-bit architecture
   instead of the default one
-- mode=RELEASE: create release build which statically links the C++ runtime and
+- MODE=release: create release build which statically links the C++ runtime and
   uses LTO
-- mode=DEBUG: create debug build
-- mode=PROFILE: create profile build
+- MODE=debug: create debug build
+- MODE=profile: create profile build
 
 
 Platforms


### PR DESCRIPTION
I noticed that the install documentation for MODE had inconsistent capitalization with the makefile. The INSTALL file listed options in the form of "mode=OPTION" while the makefile expects MODE to be capital and the option to be lowercase (see https://github.com/ufal/udpipe/blob/master/src/Makefile.builtem#L81 and other lines which reference $(MODE) with lowercase options). I believe your website also has the incorrect capitalization: http://ufal.mff.cuni.cz/udpipe/install#compilation

It took me a while to figure this out when my debug builds weren't actually debug, so I thought this update would be useful to others.

I am using Cygwin with MSVC on Windows, and this capitalization mattered for me. I can't speak for other environments though.

This project looks very promising and I'm eager to test it out.