### PR TITLE
Add example using udpipe python binding as library

### DIFF
--- a/bindings/python/examples/use_as_library.py
+++ b/bindings/python/examples/use_as_library.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from ufal.udpipe import Model, Pipeline, ProcessingError
+
+MODELS = {
+    "swe": "../udpipe-ud-1.2-160523/swedish-ud-1.2-160523.udpipe"
+}
+
+
+class Tagger:
+    def __init__(self, language):
+        model_path = MODELS.get(language, None)
+        model = Model.load(model_path)
+        if not model:
+            raise Exception("Cannot load model from file '%s'\n" % model_path)
+
+        self.model = model
+
+    def tag(self, text):
+        pipeline = Pipeline(
+            self.model,
+            "tokenize",
+            Pipeline.DEFAULT,
+            Pipeline.DEFAULT,
+            "conllu"
+        )
+        error = ProcessingError()
+
+        processed = pipeline.process(text, error)
+        if error.occurred():
+            raise Exception(error.message)
+
+        return processed
+
+if __name__ == '__main__':
+    tagger = Tagger(language="swe")
+    print(tagger.tag(u"Fördomen har alltid sin rot i vardagslivet."))


### PR DESCRIPTION
I'm interested in using udpipe inside a larger python project and looked for a way to use the python binding as a library instead of command line code. I finally managed to get it working and thought I should share the code with the next person the has the same need. Do you agree that this is useful to include?