### PR TITLE
prevent three pylint warnings

### DIFF
--- a/bindings/python/examples/run_udpipe.py
+++ b/bindings/python/examples/run_udpipe.py
@@ -9,7 +9,7 @@
 
 import sys
 
-from ufal.udpipe import *
+from ufal.udpipe import Model, Pipeline, ProcessingError # pylint: disable=no-name-in-module
 
 # In Python2, wrap sys.stdin and sys.stdout to work with unicode.
 if sys.version_info[0] < 3:

--- a/bindings/python/examples/udpipe_model.py
+++ b/bindings/python/examples/udpipe_model.py
@@ -8,6 +8,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import ufal.udpipe
+# ufal.udpipe.Model etc. are SWIG-magic and cannot be detected by pylint
+# pylint: disable=no-member
 
 class Model:
     def __init__(self, path):
@@ -23,11 +25,11 @@ class Model:
             raise Exception("The model does not have a tokenizer")
         return self._read(text, tokenizer)
 
-    def read(self, text, format):
+    def read(self, text, in_format):
         """Load text in the given format (conllu|horizontal|vertical) and return list of ufal.udpipe.Sentence-s."""
-        input_format = ufal.udpipe.InputFormat.newInputFormat(format)
+        input_format = ufal.udpipe.InputFormat.newInputFormat(in_format)
         if not input_format:
-            raise Exception("Cannot create input format '%s'" % format)
+            raise Exception("Cannot create input format '%s'" % in_format)
         return self._read(text, input_format)
 
     def _read(self, text, input_format):
@@ -52,10 +54,10 @@ class Model:
         """Parse the given ufal.udpipe.Sentence (inplace)."""
         self.model.parse(sentence, self.model.DEFAULT)
 
-    def write(self, sentences, format):
+    def write(self, sentences, out_format):
         """Write given ufal.udpipe.Sentence-s in the required format (conllu|horizontal|vertical)."""
 
-        output_format = ufal.udpipe.OutputFormat.newOutputFormat(format)
+        output_format = ufal.udpipe.OutputFormat.newOutputFormat(out_format)
         output = ''
         for sentence in sentences:
             output += output_format.writeSentence(sentence)


### PR DESCRIPTION
`format` is a Python built-in and should not be used for
variables/parameters names

Silence the no-name-in-module and no-member warnings.
Ensure the users UDPipe is right and pylint is wrong:-)