### PR TITLE
Windows specific fixes

### DIFF
--- a/src/Makefile.builtem
+++ b/src/Makefile.builtem
@@ -206,7 +206,7 @@ else ifeq ($(PLATFORM),win-vs)
     DYN_C_FLAGS += /LD
     LD_FLAGS += /OPT:REF /OPT:ICF
   else ifeq ($(MODE),debug)
-    C_FLAGS += /Od /Z7 /MTd /RTC1 /D _DEBUG
+    C_FLAGS += /Od /Z7 /MTd /RTC1 /D _DEBUG /D _ITERATOR_DEBUG_LEVEL=0
     DYN_C_FLAGS += /LDd
     LD_FLAGS += /DEBUG
   endif

--- a/src/rest_server/udpipe_service.cpp
+++ b/src/rest_server/udpipe_service.cpp
@@ -23,7 +23,7 @@ bool udpipe_service::init(const service_options& options) {
   models.clear();
   rest_models_map.clear();
   for (auto& model_description : options.model_descriptions) {
-    unique_ptr<ifstream> is(new ifstream(model_description.file));
+    unique_ptr<ifstream> is(new ifstream(model_description.file, std::ios::binary));
     if (!is->is_open()) return false;
 
     // Store the model


### PR DESCRIPTION
Open file in binary mode (not default in windows) otherwise issues with loading models. 

In debug mode the `optimisation` of filling out a matrix in one step (https://github.com/ufal/udpipe/blob/4519d870e4b57955c691178f88566329a35caf76/src/morphodita/tokenizer/gru_tokenizer_network.h#L206) triggers assertion if _ITERATOR_DEBUG_LEVEL is not set to 0.