### PR TITLE
# FIX

### DIFF
--- a/bindings/csharp/examples/RunUDPipe.cs
+++ b/bindings/csharp/examples/RunUDPipe.cs
@@ -32,8 +32,8 @@ class RunUDPipe {
         // Read whole input
         StringBuilder textBuilder = new StringBuilder();
         string line;
-        while ((line = Console.In.ReadLine()) != null)
-            textBuilder.Append(line).Append('\n');
+        while (!string.IsNullOrEmpty(line = Console.In.ReadLine()))
+            textBuilder.AppendLine(line);
 
         // Process data
         string text = textBuilder.ToString();


### PR DESCRIPTION
- Line 35: (line = Console.In.ReadLine()) != null >>> you can't exit input mode (Console.In.ReadLine() is never null)
- Line 36: Style fix ".Append(line).Append('\n')" >>> better ".AppendLine(line)"